### PR TITLE
WIP: Add ecasound

### DIFF
--- a/src/ecasound-1-remove-stuff.patch
+++ b/src/ecasound-1-remove-stuff.patch
@@ -1,0 +1,1242 @@
+From a38a8ef791dff51c129a889fbc6eb72db3ed4fca Mon Sep 17 00:00:00 2001
+From: Matthias Geier <Matthias.Geier@gmail.com>
+Date: Fri, 9 Mar 2018 18:08:27 +0100
+Subject: [PATCH] Trying to remove some things that are hopefully not needed
+
+---
+ configure                                | 117 +------
+ ecasound/Makefile.am                     |   2 -
+ ecasound/Makefile.in                     |   7 +-
+ ecasound/eca-neteci-server.cpp           | 557 -------------------------------
+ ecasound/eca-neteci-server.h             |  78 -----
+ ecasound/ecasound.cpp                    |  53 +--
+ ecasound/ecasound.h                      |   6 -
+ kvutils/Makefile.in                      |   5 +-
+ kvutils/kvu_fd_io.cpp                    | 125 -------
+ kvutils/kvu_fd_io.h                      |   8 -
+ kvutils/kvu_temporary_file_directory.cpp |   2 +-
+ 11 files changed, 6 insertions(+), 954 deletions(-)
+ delete mode 100644 ecasound/eca-neteci-server.cpp
+ delete mode 100644 ecasound/eca-neteci-server.h
+ delete mode 100644 kvutils/kvu_fd_io.cpp
+ delete mode 100644 kvutils/kvu_fd_io.h
+
+diff --git a/configure b/configure
+index 28b83ac..cfe0ede 100755
+--- a/configure
++++ b/configure
+@@ -16149,63 +16149,6 @@ ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ ac_compiler_gnu=$ac_cv_c_compiler_gnu
+ 
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing inet_ntoa" >&5
+-$as_echo_n "checking for library containing inet_ntoa... " >&6; }
+-if test "${ac_cv_search_inet_ntoa+set}" = set; then :
+-  $as_echo_n "(cached) " >&6
+-else
+-  ac_func_search_save_LIBS=$LIBS
+-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+-/* end confdefs.h.  */
+-
+-/* Override any GCC internal prototype to avoid an error.
+-   Use char because int might match the return type of a GCC
+-   builtin and then its argument prototype would still apply.  */
+-#ifdef __cplusplus
+-extern "C"
+-#endif
+-char inet_ntoa ();
+-int
+-main ()
+-{
+-return inet_ntoa ();
+-  ;
+-  return 0;
+-}
+-_ACEOF
+-for ac_lib in '' socket nsl; do
+-  if test -z "$ac_lib"; then
+-    ac_res="none required"
+-  else
+-    ac_res=-l$ac_lib
+-    LIBS="-l$ac_lib  $ac_func_search_save_LIBS"
+-  fi
+-  if ac_fn_c_try_link "$LINENO"; then :
+-  ac_cv_search_inet_ntoa=$ac_res
+-fi
+-rm -f core conftest.err conftest.$ac_objext \
+-    conftest$ac_exeext
+-  if test "${ac_cv_search_inet_ntoa+set}" = set; then :
+-  break
+-fi
+-done
+-if test "${ac_cv_search_inet_ntoa+set}" = set; then :
+-
+-else
+-  ac_cv_search_inet_ntoa=no
+-fi
+-rm conftest.$ac_ext
+-LIBS=$ac_func_search_save_LIBS
+-fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_search_inet_ntoa" >&5
+-$as_echo "$ac_cv_search_inet_ntoa" >&6; }
+-ac_res=$ac_cv_search_inet_ntoa
+-if test "$ac_res" != no; then :
+-  test "$ac_res" = "none required" || LIBS="$ac_res $LIBS"
+-
+-else
+-  as_fn_error $? "*** required inet_ntoa() function not found! ***" "$LINENO" 5
+-fi
+ 
+ { $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing nanosleep" >&5
+ $as_echo_n "checking for library containing nanosleep... " >&6; }
+@@ -16319,64 +16262,6 @@ if test "$ac_res" != no; then :
+ 
+ fi
+ 
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing socket" >&5
+-$as_echo_n "checking for library containing socket... " >&6; }
+-if test "${ac_cv_search_socket+set}" = set; then :
+-  $as_echo_n "(cached) " >&6
+-else
+-  ac_func_search_save_LIBS=$LIBS
+-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+-/* end confdefs.h.  */
+-
+-/* Override any GCC internal prototype to avoid an error.
+-   Use char because int might match the return type of a GCC
+-   builtin and then its argument prototype would still apply.  */
+-#ifdef __cplusplus
+-extern "C"
+-#endif
+-char socket ();
+-int
+-main ()
+-{
+-return socket ();
+-  ;
+-  return 0;
+-}
+-_ACEOF
+-for ac_lib in '' socket nsl; do
+-  if test -z "$ac_lib"; then
+-    ac_res="none required"
+-  else
+-    ac_res=-l$ac_lib
+-    LIBS="-l$ac_lib  $ac_func_search_save_LIBS"
+-  fi
+-  if ac_fn_c_try_link "$LINENO"; then :
+-  ac_cv_search_socket=$ac_res
+-fi
+-rm -f core conftest.err conftest.$ac_objext \
+-    conftest$ac_exeext
+-  if test "${ac_cv_search_socket+set}" = set; then :
+-  break
+-fi
+-done
+-if test "${ac_cv_search_socket+set}" = set; then :
+-
+-else
+-  ac_cv_search_socket=no
+-fi
+-rm conftest.$ac_ext
+-LIBS=$ac_func_search_save_LIBS
+-fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_search_socket" >&5
+-$as_echo "$ac_cv_search_socket" >&6; }
+-ac_res=$ac_cv_search_socket
+-if test "$ac_res" != no; then :
+-  test "$ac_res" = "none required" || LIBS="$ac_res $LIBS"
+-
+-else
+-  as_fn_error $? "*** required socket() function not found! ***" "$LINENO" 5
+-fi
+-
+ { $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing sin" >&5
+ $as_echo_n "checking for library containing sin... " >&6; }
+ if test "${ac_cv_search_sin+set}" = set; then :
+@@ -17962,7 +17847,7 @@ $as_echo "#define TIME_WITH_SYS_TIME 1" >>confdefs.h
+ 
+ fi
+ 
+-for ac_header in dlfcn.h errno.h fcntl.h regex.h signal.h unistd.h sys/poll.h sys/stat.h sys/socket.h sys/time.h sys/types.h sys/wait.h sys/select.h
++for ac_header in dlfcn.h errno.h fcntl.h regex.h signal.h unistd.h sys/stat.h sys/time.h sys/types.h
+ do :
+   as_ac_Header=`$as_echo "ac_cv_header_$ac_header" | $as_tr_sh`
+ ac_fn_c_check_header_mongrel "$LINENO" "$ac_header" "$as_ac_Header" "$ac_includes_default"
+diff --git a/ecasound/Makefile.am b/ecasound/Makefile.am
+index 7346a51..4f1377a 100644
+--- a/ecasound/Makefile.am
++++ b/ecasound/Makefile.am
+@@ -23,8 +23,6 @@ ecasound_SOURCES = 	ecasound.cpp \
+ 			eca-curses.cpp \
+ 			eca-comhelp.cpp \
+ 			eca-comhelp.h \
+-			eca-neteci-server.cpp \
+-			eca-neteci-server.h \
+ 			eca-plaintext.h \
+ 			eca-plaintext.cpp \
+ 			textdebug.cpp \
+diff --git a/ecasound/Makefile.in b/ecasound/Makefile.in
+index ca84ce4..eba9ee6 100644
+--- a/ecasound/Makefile.in
++++ b/ecasound/Makefile.in
+@@ -52,7 +52,7 @@ am__installdirs = "$(DESTDIR)$(bindir)"
+ binPROGRAMS_INSTALL = $(INSTALL_PROGRAM)
+ PROGRAMS = $(bin_PROGRAMS)
+ am_ecasound_OBJECTS = ecasound.$(OBJEXT) eca-curses.$(OBJEXT) \
+-	eca-comhelp.$(OBJEXT) eca-neteci-server.$(OBJEXT) \
++	eca-comhelp.$(OBJEXT) \
+ 	eca-plaintext.$(OBJEXT) textdebug.$(OBJEXT)
+ ecasound_OBJECTS = $(am_ecasound_OBJECTS)
+ am__DEPENDENCIES_1 =
+@@ -61,7 +61,7 @@ ecasound_DEPENDENCIES = $(am__DEPENDENCIES_2) $(am__DEPENDENCIES_1) \
+ 	$(top_builddir)/libecasound/libecasound.la \
+ 	$(top_builddir)/kvutils/libkvutils.la
+ am__objects_1 = ecasound.$(OBJEXT) eca-curses.$(OBJEXT) \
+-	eca-comhelp.$(OBJEXT) eca-neteci-server.$(OBJEXT) \
++	eca-comhelp.$(OBJEXT) \
+ 	eca-plaintext.$(OBJEXT) textdebug.$(OBJEXT)
+ am_ecasound_debug_OBJECTS = $(am__objects_1)
+ ecasound_debug_OBJECTS = $(am_ecasound_debug_OBJECTS)
+@@ -284,8 +284,6 @@ ecasound_SOURCES = ecasound.cpp \
+ 			eca-curses.cpp \
+ 			eca-comhelp.cpp \
+ 			eca-comhelp.h \
+-			eca-neteci-server.cpp \
+-			eca-neteci-server.h \
+ 			eca-plaintext.h \
+ 			eca-plaintext.cpp \
+ 			textdebug.cpp \
+@@ -380,7 +378,6 @@ distclean-compile:
+ 
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eca-comhelp.Po@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eca-curses.Po@am__quote@
+-@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eca-neteci-server.Po@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eca-plaintext.Po@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/ecasound.Po@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/textdebug.Po@am__quote@
+diff --git a/ecasound/eca-neteci-server.cpp b/ecasound/eca-neteci-server.cpp
+deleted file mode 100644
+index 16c9d0f..0000000
+--- a/ecasound/eca-neteci-server.cpp
++++ /dev/null
+@@ -1,557 +0,0 @@
+-// ------------------------------------------------------------------------
+-// eca-neteci-server.c: NetECI server implementation.
+-// Copyright (C) 2002,2004,2009 Kai Vehmanen
+-//
+-// Attributes:
+-//     eca-style-version: 3
+-//
+-// This program is free software; you can redistribute it and/or modify
+-// it under the terms of the GNU General Public License as published by
+-// the Free Software Foundation; either version 2 of the License, or
+-// (at your option) any later version.
+-// 
+-// This program is distributed in the hope that it will be useful,
+-// but WITHOUT ANY WARRANTY; without even the implied warranty of
+-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-// GNU General Public License for more details.
+-// 
+-// You should have received a copy of the GNU General Public License
+-// along with this program; if not, write to the Free Software
+-// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA
+-// ------------------------------------------------------------------------
+-
+-#include <cassert>
+-#include <cstring>        /* memcpy() */
+-#include <iostream>
+-#include <string>
+-
+-#include <fcntl.h>        /* POSIX: fcntl() */
+-#include <pthread.h>      /* POSIX: pthread_* */
+-#include <unistd.h>       /* POSIX: fcntl() */
+-#include <arpa/inet.h>    /* BSD: inet_ntoa() */
+-#include <netinet/in.h>   /* BSD: inet_ntoa() */
+-#include <sys/poll.h>     /* POSIX: poll() */
+-#include <sys/socket.h>   /* BSD: getpeername() */
+-#include <sys/types.h>    /* OSX: u_int32_t (INADDR_ANY) */
+-
+-#include <kvu_dbc.h>
+-#include <kvu_fd_io.h>
+-#include <kvu_numtostr.h>
+-#include <kvu_utils.h>
+-
+-#include <eca-control-mt.h>
+-#include <eca-logger.h>
+-#include <eca-logger-wellformed.h>
+-
+-#include "ecasound.h"
+-#include "eca-neteci-server.h"
+-
+-/** 
+- * Options
+- */
+-// #define NETECI_DEBUG_ENABLED
+-
+-#define ECA_NETECI_START_BUFFER_SIZE    128
+-#define ECA_NETECI_MAX_BUFFER_SIZE      65536
+-
+-/**
+- * Macro definitions
+- */
+-
+-#ifdef NETECI_DEBUG_ENABLED
+-#define NETECI_DEBUG(x) x
+-#else
+-#define NETECI_DEBUG(x) ((void) 0)
+-#endif
+-
+-/** 
+- * Import namespaces
+- */
+-
+-using namespace std;
+-
+-ECA_NETECI_SERVER::ECA_NETECI_SERVER(ECASOUND_RUN_STATE* state)
+-  : state_repp(state),
+-    srvfd_rep(-1),
+-    server_listening_rep(false),
+-    unix_sockets_rep(false),
+-    cleanup_request_rep(false)
+-{
+-}
+-
+-ECA_NETECI_SERVER::~ECA_NETECI_SERVER(void)
+-{
+-  if (server_listening_rep == true) {
+-    close_server_socket();
+-  }
+-}
+-
+-/**
+- * Launches the server thread.
+- *
+- * @param arg pointer to a ECA_NETECI_SERVER object
+- */
+-void* ECA_NETECI_SERVER::launch_server_thread(void* arg)
+-{
+-  ECA_LOG_MSG(ECA_LOGGER::user_objects, "Server thread started");
+-
+-  ECA_NETECI_SERVER* self = 
+-    reinterpret_cast<ECA_NETECI_SERVER*>(arg);
+-  self->run();
+-  return 0;
+-}
+-
+-/**
+- * Starts running the NetECI server. 
+- *
+- * After calling this function, the ECA_CONTROL_MAIN object
+- * may be used at any time from the NetECI server thread.
+- */ 
+-void ECA_NETECI_SERVER::run(void)
+-{
+-  create_server_socket();
+-  open_server_socket();
+-  if (server_listening_rep == true) {
+-    listen_for_events();
+-  }
+-  else {
+-    ECA_LOG_MSG(ECA_LOGGER::info, 
+-		"Unable to start NetECI server. Please check that no other program is using the TCP port "
+-		+ kvu_numtostr(state_repp->neteci_tcp_port)
+-		+ ".");
+-  }
+-  close_server_socket();
+-
+-  ECA_LOG_MSG(ECA_LOGGER::user_objects, 
+-	      "server thread exiting");
+-}
+-
+-/**
+- * Creates a server socket with 'socket()'. Depending on 
+- * object configuration either UNIX or IP socket is 
+- * created.
+- */
+-void ECA_NETECI_SERVER::create_server_socket(void)
+-{
+-  DBC_REQUIRE(server_listening_rep != true);
+-  DBC_REQUIRE(srvfd_rep <= 0);
+-
+-  if (unix_sockets_rep == true) {
+-    srvfd_rep = socket(AF_UNIX, SOCK_STREAM, 0);
+-    if (srvfd_rep >= 0) {
+-      /* create a temporary filename for the socket in a secure way */
+-      socketpath_rep = "/tmp/neteci_server_1";
+-      addr_un_rep.sun_family = AF_UNIX;
+-      memcpy(addr_un_rep.sun_path, socketpath_rep.c_str(), socketpath_rep.size() + 1);
+-      addr_repp = reinterpret_cast<struct sockaddr*>(&addr_un_rep);
+-    }
+-  }
+-  else {
+-    srvfd_rep = socket(PF_INET, SOCK_STREAM, 0);
+-    if (srvfd_rep >= 0) {
+-      addr_in_rep.sin_family = AF_INET;
+-      addr_in_rep.sin_port = htons(state_repp->neteci_tcp_port);
+-      addr_in_rep.sin_addr.s_addr = INADDR_ANY;
+-      
+-      addr_repp = reinterpret_cast<struct sockaddr*>(&addr_in_rep);
+-    }
+-  }
+-}
+-
+-/**
+- * Opens the server socket for listening. If succesful,
+- * 'server_listening_rep' will be true after the call.
+- */
+-void ECA_NETECI_SERVER::open_server_socket(void)
+-{
+-  DBC_REQUIRE(server_listening_rep != true);
+-  DBC_REQUIRE(srvfd_rep > 0);
+-
+-  int val = 1;
+-  int ret = setsockopt(srvfd_rep, SOL_SOCKET, SO_REUSEADDR, (void *)&val, sizeof(val));
+-  if (ret < 0) 
+-    std::cerr << "setsockopt() failed." << endl;
+-  
+-  // int res = bind(srvfd_rep, (struct sockaddr*)addr_repp, sizeof(*addr_repp));
+-  
+-  int res = 0;
+-  if (unix_sockets_rep == true) 
+-    res = bind(srvfd_rep, (struct sockaddr*)&addr_un_rep, sizeof(addr_un_rep));
+-  else
+-    res = bind(srvfd_rep, (struct sockaddr*)&addr_in_rep, sizeof(addr_in_rep));
+-  
+-  if (res == 0) {
+-    res = listen(srvfd_rep, 5);
+-    if (res == 0) {
+-      int res = fcntl(srvfd_rep, F_SETFL, O_NONBLOCK);
+-      if (res == -1) 
+-	std::cerr << "fcntl() failed." << endl;
+-      
+-      NETECI_DEBUG(std::cout << "server socket created." << endl);
+-      server_listening_rep = true;
+-    }
+-    else 
+-      std::cerr << "listen() failed." << endl;
+-  }
+-  else {
+-    if (unix_sockets_rep == true) {
+-      unlink(socketpath_rep.c_str());
+-    }
+-    socketpath_rep.resize(0);
+-    std::cerr << "bind() failed." << endl;
+-  }
+-  
+-  DBC_ENSURE((unix_sockets_rep == true && 
+-	     (((server_listening_rep == true && socketpath_rep.size() > 0) ||
+-	       (server_listening_rep != true && socketpath_rep.size() == 0)))) ||
+-	     (unix_sockets_rep != true));
+-}
+-
+-/**
+- * Closes the server socket.
+- */
+-void ECA_NETECI_SERVER::close_server_socket(void)
+-{
+-  DBC_REQUIRE(srvfd_rep > 0);
+-  DBC_REQUIRE(server_listening_rep == true);
+-
+-  NETECI_DEBUG(cerr << "closing socket " << kvu_numtostr(srvfd_rep) << "." << endl);
+-  close(srvfd_rep);
+-  srvfd_rep = -1;
+-  server_listening_rep = false;
+-
+-  DBC_ENSURE(srvfd_rep == -1);
+-  DBC_ENSURE(server_listening_rep != true);
+-}
+-
+-/**
+- * Listens for and accepts incoming connections.
+- */
+-void ECA_NETECI_SERVER::listen_for_events(void)
+-{
+-  /* 
+-   * - loop until we get an exit request from network or from
+-   *   ecasound_state
+-   */
+-  
+-  /* - enter poll
+-   * - if new connections, accept them and add the new client to
+-   *   client list
+-   * - if incoming bytes, grab ecasound_state lock, send command,
+-   *   store retval, release lock, send the reply to client
+-   * - return to poll
+-   */
+-  while(state_repp->exit_requested() != true) {
+-    // NETECI_DEBUG(cerr << "checking for events" << endl);
+-    check_for_events(2000);
+-  }
+-
+-  if (state_repp->exit_requested() == true) {
+-    NETECI_DEBUG(cerr << "exit_request received" << endl);
+-  }
+-}
+-
+-/**
+- * Checks for new connections and messages from 
+- * clients.
+- * 
+- * @param timeout upper-limit in ms for how long 
+- *        function waits for events; if -1, 
+- *        call will return immediately
+- *        (ie. is non-blocking)
+- */
+-void ECA_NETECI_SERVER::check_for_events(int timeout)
+-{
+-  int nfds = clients_rep.size() + 1;
+-  struct pollfd* ufds = new struct pollfd [nfds];
+-
+-  ufds[0].fd = srvfd_rep;
+-  ufds[0].events = POLLIN;
+-  ufds[0].revents = 0;
+-  
+-  std::list<struct ecasound_neteci_server_client*>::iterator p = clients_rep.begin();
+-  for(int n = 1; n < nfds; n++) {
+-    ufds[n].fd = (*p)->fd;
+-    ufds[n].events = POLLIN;
+-    ufds[n].revents = 0;
+-    ++p;
+-  }
+-  DBC_CHECK(nfds == 1 || p == clients_rep.end());
+-
+-  int ret = poll(ufds, nfds, timeout);
+-  if (ret > 0) {
+-    if (ufds[0].revents & POLLIN) {
+-      /* 1. new incoming connection */
+-      handle_connection(srvfd_rep);
+-    }
+-    p = clients_rep.begin();
+-    for(int n = 1; n < nfds; n++) {
+-      if (ufds[n].revents & POLLIN) {
+-	/* 2. client has sent a message */
+-	handle_client_messages(*p);
+-      }
+-      else if (ufds[n].revents == POLLERR ||
+-	       ufds[n].revents == POLLHUP ||
+-	       ufds[n].revents == POLLNVAL) {
+-	/* 3. error, remove client */
+-	remove_client(*p);
+-      }
+-      if (p != clients_rep.end()) ++p;
+-    }
+-  }
+-
+-  if (cleanup_request_rep == true) {
+-    clean_removed_clients();
+-  }
+-
+-  delete[] ufds;
+-}
+-
+-void ECA_NETECI_SERVER::handle_connection(int fd)
+-{
+-  socklen_t bytes = 0;
+-  string peername;
+-  int connfd = 0;
+-
+-  if (unix_sockets_rep == true) {
+-    bytes = static_cast<socklen_t>(sizeof(addr_un_rep));
+-    connfd = accept(fd, reinterpret_cast<struct sockaddr*>(&addr_un_rep), &bytes);
+-    peername = "UNIX:" + socketpath_rep;
+-  }
+-  else {
+-    bytes = static_cast<socklen_t>(sizeof(addr_in_rep));
+-    connfd = accept(fd, reinterpret_cast<struct sockaddr*>(&addr_in_rep), &bytes);
+-
+-    if (connfd > 0) {
+-      struct sockaddr_in peeraddr;
+-      socklen_t peernamelen;
+-      // struct in_addr peerip;
+-      peername = "TCP/IP:";
+-      int res = getpeername(connfd, 
+-			    reinterpret_cast<struct sockaddr*>(&peeraddr), 
+-			    reinterpret_cast<socklen_t*>(&peernamelen));
+-      if (res == 0)
+-	peername += string(inet_ntoa(peeraddr.sin_addr));
+-      else
+-	peername += string(inet_ntoa(addr_in_rep.sin_addr));
+-    }
+-  }
+-
+-  ECA_LOG_MSG(ECA_LOGGER::info,
+-	      "New connection from " + 
+-	      peername + ".");
+-
+-
+-  if (connfd >= 0) {
+-    NETECI_DEBUG(cerr << "incoming connection accepted" << endl);
+-    struct ecasound_neteci_server_client* client = new struct ecasound_neteci_server_client; /* add a new client */
+-    client->fd = connfd; 
+-    client->buffer_length = ECA_NETECI_START_BUFFER_SIZE;
+-    client->buffer = new char [client->buffer_length];
+-    client->buffer_current_ptr = 0;
+-    client->peername = peername;
+-    clients_rep.push_back(client);
+-  }
+-}
+-
+-/**
+- * Handle incoming messages for client 'client'.
+- */
+-void ECA_NETECI_SERVER::handle_client_messages(struct ecasound_neteci_server_client* client)
+-{
+-  char* buf[128];
+-  int connfd = client->fd;
+-
+-  NETECI_DEBUG(cerr << "handle_client_messages for fd " 
+-	       << connfd << endl);
+-
+-  ssize_t c = kvu_fd_read(connfd, buf, 128, 5000);
+-  if (c > 0) {
+-    parse_raw_incoming_data(reinterpret_cast<char*>(buf), c, client);
+-    while(parsed_cmd_queue_rep.size() > 0) {
+-      const string& nextcmd = parsed_cmd_queue_rep.front();
+-      if (nextcmd == "quit" || nextcmd == "q") {
+-	NETECI_DEBUG(cerr << "client initiated quit, removing client-fd " << connfd << "." << endl);
+-	remove_client(client);
+-      }
+-      else {
+-	handle_eci_command(nextcmd, client);
+-      }
+-      parsed_cmd_queue_rep.pop_front();
+-    }
+-    /* ... */
+-  }
+-  else {
+-    /* read() <= 0 */
+-    NETECI_DEBUG(cerr << "read error, removing client-fd " << connfd << "." << endl);
+-    remove_client(client);
+-  }
+-}
+-
+-void ECA_NETECI_SERVER::parse_raw_incoming_data(const char* buffer,
+-						ssize_t bytes,
+-						struct ecasound_neteci_server_client* client)
+-{
+-  DBC_REQUIRE(buffer != 0);
+-  DBC_REQUIRE(bytes >= 0);
+-  DBC_REQUIRE(client != 0);
+-  DBC_DECLARE(int old_client_ptr = client->buffer_current_ptr);
+-  DBC_DECLARE(unsigned int old_cmd_queue_size = parsed_cmd_queue_rep.size());
+-
+-  NETECI_DEBUG(cerr << "parse incoming data; "
+-	       << bytes << " bytes. Buffer length is " 
+-	       << client->buffer_length << endl);
+-  
+-  for(int n = 0; n < bytes; n++) {
+-    DBC_CHECK(client->buffer_current_ptr <= client->buffer_length);
+-    if (client->buffer_current_ptr == client->buffer_length) {
+-      int new_buffer_length = client->buffer_length * 2;
+-      char *new_buffer = new char [new_buffer_length];
+-
+-      if (new_buffer_length > ECA_NETECI_MAX_BUFFER_SIZE) {
+-	cerr << "client buffer overflow, unable to increase buffer size. flushing..." << endl;
+-	client->buffer_current_ptr = 0;
+-      }
+-      else {
+-	NETECI_DEBUG(cerr << "client buffer overflow, increasing buffer size from "
+-		     << client->buffer_length << " to " << new_buffer_length << " bytes." << endl);
+-	
+-	for(int i = 0; i < client->buffer_length; i++) new_buffer[i] = client->buffer[i];
+-	
+-	delete[] client->buffer;
+-	client->buffer = new_buffer;
+-	client->buffer_length = new_buffer_length;
+-      }
+-    }
+-
+-    NETECI_DEBUG(cerr << "copying '" << buffer[n] << "'\n");
+-    client->buffer[client->buffer_current_ptr] = buffer[n];
+-    if (client->buffer_current_ptr > 0 &&
+-	client->buffer[client->buffer_current_ptr] == '\n' &&
+-	client->buffer[client->buffer_current_ptr - 1] == '\r') {
+-
+-      string cmd (client->buffer, client->buffer_current_ptr - 1);
+-      NETECI_DEBUG(cerr << "storing command '" <<	cmd << "'" << endl);
+-      parsed_cmd_queue_rep.push_back(cmd);
+-      
+-      NETECI_DEBUG(cerr << "copying " 
+-		   << client->buffer_length - client->buffer_current_ptr - 1
+-		   << " bytes from " << client->buffer_current_ptr + 1 
+-		   << " to the beginning of the buffer."
+-		   << " Index is " << client->buffer_current_ptr << endl);
+-      
+-      DBC_CHECK(client->buffer_current_ptr < client->buffer_length);
+-      
+-#if 0
+-      /* must not use memcpy() as the 
+-	 affected areas may overlap! */
+-      for(int o = 0, p = index + 1; 
+-	  p < client->buffer_length; o++, p++) {
+-	client->buffer[o] = client->buffer[p];
+-      }
+-#endif
+-      client->buffer_current_ptr = 0;
+-    }
+-    else {
+-      // NETECI_DEBUG(cerr << "crlf not found, index=" << index << ", n=" << n << "cur_ptr=" << client->buffer_current_ptr << ".\n");
+-      client->buffer_current_ptr++;
+-    }
+-  }
+-
+-  DBC_ENSURE(client->buffer_current_ptr > old_client_ptr ||
+-	     parsed_cmd_queue_rep.size() > old_cmd_queue_size);
+-}
+-
+-void ECA_NETECI_SERVER::handle_eci_command(const string& cmd, struct ecasound_neteci_server_client* client)
+-{
+-  ECA_CONTROL_MT* ctrl = state_repp->control;
+-
+-  NETECI_DEBUG(cerr << "handle eci command: " << cmd << endl);
+-
+-  assert(ctrl != 0);
+-
+-  struct eci_return_value retval;
+-  ctrl->command(cmd, &retval);
+-
+-  string strtosend =
+-    ECA_LOGGER_WELLFORMED::create_wellformed_message(ECA_LOGGER::eiam_return_values,
+-      std::string(ECA_CONTROL_MAIN::return_value_type_to_string(&retval))
+-      + " " + 
+-      ECA_CONTROL_MAIN::return_value_to_string(&retval));
+-
+-  int bytes_to_send = strtosend.size();
+-  while(bytes_to_send > 0) {
+-    int ret = kvu_fd_write(client->fd, strtosend.c_str(), strtosend.size(), 5000);
+-    if (ret < 0) {
+-      cerr << "error in kvu_fd_write(), removing client.\n";
+-      remove_client(client);
+-      break;
+-    }
+-    else {
+-      bytes_to_send -= ret;
+-    }
+-  }
+-}
+-
+-/**
+- * Removes 'client' from list of clients.
+- *
+- * Note! Internally, the 'fd' field of the deleted client 
+- * is marked to be -1.
+- *
+- * @see clean_removed_clients()
+- */
+-void ECA_NETECI_SERVER::remove_client(struct ecasound_neteci_server_client* client)
+-{
+-  NETECI_DEBUG(std::cout << "removing client." << std::endl);
+-
+-  if (client != 0 && client->fd > 0) {
+-    ECA_LOG_MSG(ECA_LOGGER::info, 
+-		"Closing connection " +
+-		client->peername + ".");
+-    close(client->fd);
+-    client->fd = -1;
+-  }
+-
+-  cleanup_request_rep = true;
+-}
+-
+-/**
+- * Cleans the list of clients from removed objects.
+- *
+- * @see remove_client()
+- */
+-void ECA_NETECI_SERVER::clean_removed_clients(void)
+-{
+-  DBC_DECLARE(size_t oldsize = clients_rep.size());
+-  DBC_DECLARE(size_t counter = 0);
+-
+-  NETECI_DEBUG(std::cerr << "cleaning removed clients." << std::endl);
+-
+-  list<struct ecasound_neteci_server_client*>::iterator p = clients_rep.begin();
+-  while(p != clients_rep.end()) {
+-    NETECI_DEBUG(std::cerr << "checking for delete, client " << *p << std::endl);
+-    if (*p != 0 && (*p)->fd == -1) {
+-      if ((*p)->buffer != 0) {
+-	delete[] (*p)->buffer;
+-	(*p)->buffer = 0;
+-      }
+-      std::list<struct ecasound_neteci_server_client*>::iterator q = p;
+-      ++q;
+-      NETECI_DEBUG(std::cerr << "deleting client " << *p << std::endl);
+-      delete *p;
+-      NETECI_DEBUG(std::cerr << "erasing client " << *p << std::endl);
+-      *p = 0;
+-      clients_rep.erase(p);
+-      p = q;
+-      DBC_DECLARE(++counter);
+-    }
+-    else {
+-      ++p;
+-    }
+-  }
+-  
+-  cleanup_request_rep = false;
+-
+-  DBC_ENSURE(clients_rep.size() == oldsize - counter);
+-}
+diff --git a/ecasound/eca-neteci-server.h b/ecasound/eca-neteci-server.h
+deleted file mode 100644
+index a97302e..0000000
+--- a/ecasound/eca-neteci-server.h
++++ /dev/null
+@@ -1,78 +0,0 @@
+-#ifndef INCLUDED_ECA_NETECI_SERVER_H
+-#define INCLUDED_ECA_NETECI_SERVER_H
+-
+-#include <list>
+-#include <string>
+-
+-#include <sys/socket.h>   /* Generic socket definitions */
+-#include <sys/un.h>       /* UNIX socket definitions */
+-#include <netinet/in.h>   /* IP socket definitions */
+-
+-struct ecasound_state;
+-class ECASOUND_RUN_STATE;
+-
+-struct ecasound_neteci_server_client {
+-  std::string peername;
+-  char* buffer;
+-  int fd;
+-  int buffer_current_ptr;
+-  int buffer_length;
+-};
+-
+-/**
+- * NetECI server implementation.
+- *
+- * @author Kai Vehmanen
+- */
+-class ECA_NETECI_SERVER {
+-
+- public:
+-
+-  /**
+-   * Constructor.
+-   */
+-  ECA_NETECI_SERVER(ECASOUND_RUN_STATE* state);
+-
+-  /**
+-   * Virtual destructor.
+-   */
+-  ~ECA_NETECI_SERVER(void);
+-
+-  static void* launch_server_thread(void* arg);
+-
+- private:
+-
+-  void run(void);
+-
+-  void create_server_socket(void);
+-  void open_server_socket(void);
+-  void close_server_socket(void);
+-  void listen_for_events(void);
+-  void check_for_events(int timeout);
+-  void handle_connection(int fd);
+-  void handle_client_messages(struct ecasound_neteci_server_client* client);
+-  void handle_eci_command(const std::string& cmd, struct ecasound_neteci_server_client* client);
+-  void parse_raw_incoming_data(const char* buffer, 
+-			       ssize_t bytes,
+-			       struct ecasound_neteci_server_client* client);
+-  void remove_client(struct ecasound_neteci_server_client* client);
+-  void clean_removed_clients(void);
+-
+-  struct sockaddr_un addr_un_rep;
+-  struct sockaddr_in addr_in_rep;
+-  struct sockaddr* addr_repp;
+-  ECASOUND_RUN_STATE* state_repp;
+-
+-  std::list<struct ecasound_neteci_server_client*> clients_rep;
+-  /* FIXME: turn into a buffer of pointers to allow ptr-fields */
+-  std::list<std::string> parsed_cmd_queue_rep;
+-  std::string socketpath_rep;
+-
+-  int srvfd_rep;
+-  bool server_listening_rep;
+-  bool unix_sockets_rep;
+-  bool cleanup_request_rep;
+-
+-};
+-
+-#endif /* INCLUDED_ECA_NETECI_SERVER_H */
+diff --git a/ecasound/ecasound.cpp b/ecasound/ecasound.cpp
+index cbb915e..861145a 100644
+--- a/ecasound/ecasound.cpp
++++ b/ecasound/ecasound.cpp
+@@ -52,7 +52,6 @@
+ #include "eca-comhelp.h"
+ #include "eca-console.h"
+ #include "eca-curses.h"
+-#include "eca-neteci-server.h"
+ #include "eca-plaintext.h"
+ #include "textdebug.h"
+ #include "ecasound.h"
+@@ -70,7 +69,6 @@
+  */
+ 
+ static void ecasound_create_eca_objects(ECASOUND_RUN_STATE* state, COMMAND_LINE& cline);
+-static void ecasound_launch_neteci(ECASOUND_RUN_STATE* state);
+ static void ecasound_launch_osc(ECASOUND_RUN_STATE* state);
+ static int ecasound_pass_at_launch_commands(ECASOUND_RUN_STATE* state);
+ static void ecasound_main_loop_interactive(ECASOUND_RUN_STATE* state);
+@@ -144,18 +142,14 @@ ECASOUND_RUN_STATE::ECASOUND_RUN_STATE(void)
+   : console(0),
+     control(0),
+     logger(0),
+-    eciserver(0),
+     osc(0),
+     session(0),
+     launchcmds(0),
+-    neteci_thread(0),
+     watchdog_thread(0),
+     wd_alive(false),
+     exit_request_rep(0),
+     signalset(0),
+     retval(ECASOUND_RETVAL_SUCCESS),
+-    neteci_mode(false),
+-    neteci_tcp_port(2868),
+     osc_mode(false),
+     osc_udp_port(-1),
+     keep_running_mode(false),
+@@ -176,12 +170,10 @@ ECASOUND_RUN_STATE::~ECASOUND_RUN_STATE(void)
+   if (session != 0) { delete session; session = 0; }
+ 
+   if (launchcmds != 0) { delete launchcmds; launchcmds = 0; }
+-  if (eciserver != 0) { delete eciserver; eciserver = 0; }
+ #ifdef ECA_USE_LIBLO
+   if (osc != 0) { delete osc; osc = 0; }
+ #endif
+   if (console != 0) { delete console; console = 0; }
+-  if (neteci_thread != 0) { delete neteci_thread; neteci_thread = 0; }
+   if (watchdog_thread != 0) { delete watchdog_thread; watchdog_thread = 0; }
+   if (signalset != 0) { delete signalset; signalset = 0; }
+ 
+@@ -271,10 +263,6 @@ int main(int argc, char *argv[])
+ 
+     /* 7. enable remote control over socket connection  */
+     if (state.retval == ECASOUND_RETVAL_SUCCESS) {
+-      /* 7.a) ... ECI over socket connection */
+-      if (state.neteci_mode == true) {
+-	ecasound_launch_neteci(&state);
+-      }
+       /* 7.b) ... over OSC */
+       if (state.osc_mode == true) {
+ 	ecasound_launch_osc(&state);
+@@ -295,14 +283,6 @@ int main(int argc, char *argv[])
+ 
+   TRACE_EXIT(cerr << endl << "ecasound: out of mainloop..." << endl);
+ 
+-  /* step: terminate neteci thread */
+-  if (state.neteci_mode == true) {
+-    /* wait until the NetECI thread has exited */
+-    state.exit_request();
+-    if (state.neteci_thread)
+-      pthread_join(*state.neteci_thread, NULL);
+-  }
+-
+   /* step: terminate the engine thread */
+   if (state.control != 0) {
+     if (state.control->is_running() == true) {
+@@ -373,34 +353,6 @@ void ecasound_create_eca_objects(ECASOUND_RUN_STATE* state,
+   }
+ }
+ 
+-/**
+- * Launches a background thread that allows NetECI 
+- * clients to connect to the current ecasound
+- * session.
+- */
+-void ecasound_launch_neteci(ECASOUND_RUN_STATE* state)
+-{
+-  DBC_REQUIRE(state != 0);
+-  // DBC_REQUIRE(state->console != 0);
+-
+-  // state->console->print("ecasound: starting the NetECI server.");
+-
+-  state->neteci_thread = new pthread_t;
+-  state->eciserver = new ECA_NETECI_SERVER(state);
+-
+-  int res = pthread_create(state->neteci_thread, 
+-			   NULL,
+-			   ECA_NETECI_SERVER::launch_server_thread, 
+-			   reinterpret_cast<void*>(state->eciserver));
+-  if (res != 0) {
+-    cerr << "ecasound: Warning! Unable to create a thread for control over socket connection (NetECI)." << endl;
+-    delete state->neteci_thread;  state->neteci_thread = 0;
+-    delete state->eciserver; state->eciserver = 0;
+-  }
+-
+-  // state->console->print("ecasound: NetECI server started");
+-}
+-
+ /**
+  * Sets up and activates Ecasound OSC interface
+  */
+@@ -480,7 +432,7 @@ void ecasound_main_loop_batch(ECASOUND_RUN_STATE* state)
+     ctrl->connect_chainsetup(&connect_retval);
+   }
+   
+-  if (state->neteci_mode != true &&
++  if (
+       state->osc_mode != true) {
+ 
+     /* case: 2.1: non-interactive, neither NetECI or OSC is used,
+@@ -599,7 +551,6 @@ void ecasound_parse_command_line(ECASOUND_RUN_STATE* state,
+       else if (cline.current() == "--server" ||
+ 	       cline.current() == "--daemon") {
+ 	/* note: --daemon* deprecated as of 2.6.0 */
+-	state->neteci_mode = true;
+       }
+ 
+       else if (cline.current().compare(0, 2, "-E") == 0) {
+@@ -618,14 +569,12 @@ void ecasound_parse_command_line(ECASOUND_RUN_STATE* state,
+ 	if (argpair.size() > 1) {
+ 	  /* --server-tcp-port=XXXX */
+ 	  /* note: --daemon* deprecated as of 2.6.0 */
+-	  state->neteci_tcp_port = atoi(argpair[1].c_str());
+ 	}
+       }
+ 
+       else if (cline.current() == "--no-server" ||
+ 	       cline.current() == "--nodaemon") {
+ 	/* note: --daemon deprecated as of 2.6.0 */
+-	state->neteci_mode = false;
+       }
+ 
+       else if (cline.current().find("--osc-udp-port") != string::npos) {
+diff --git a/ecasound/ecasound.h b/ecasound/ecasound.h
+index 23bdd40..34570c4 100644
+--- a/ecasound/ecasound.h
++++ b/ecasound/ecasound.h
+@@ -10,7 +10,6 @@
+ class ECA_CONSOLE;
+ class ECA_CONTROL_MT;
+ class ECA_LOGGER_INTERFACE;
+-class ECA_NETECI_SERVER;
+ class ECA_SESSION;
+ class ECA_OSC_INTERFACE;
+ 
+@@ -49,12 +48,10 @@ class ECASOUND_RUN_STATE {
+   ECA_CONSOLE* console;
+   ECA_CONTROL_MT* control;
+   ECA_LOGGER_INTERFACE* logger;
+-  ECA_NETECI_SERVER* eciserver;
+   ECA_OSC_INTERFACE* osc;
+   ECA_SESSION* session;
+   std::vector<std::string>* launchcmds;
+ 
+-  pthread_t* neteci_thread;
+   pthread_t* watchdog_thread;
+   pthread_mutex_t lock_rep;
+   pthread_cond_t cond_rep;
+@@ -64,9 +61,6 @@ class ECASOUND_RUN_STATE {
+ 
+   int retval;
+ 
+-  bool neteci_mode;
+-  int neteci_tcp_port;
+-
+   bool osc_mode;
+   int osc_udp_port;
+ 
+diff --git a/kvutils/Makefile.in b/kvutils/Makefile.in
+index c2e53d0..965456b 100644
+--- a/kvutils/Makefile.in
++++ b/kvutils/Makefile.in
+@@ -65,7 +65,7 @@ am__installdirs = "$(DESTDIR)$(libdir)"
+ libLTLIBRARIES_INSTALL = $(INSTALL)
+ LTLIBRARIES = $(lib_LTLIBRARIES)
+ libkvutils_la_LIBADD =
+-am__objects_1 = kvu_dbc.lo kvu_debug.lo kvu_com_line.lo kvu_fd_io.lo \
++am__objects_1 = kvu_dbc.lo kvu_debug.lo kvu_com_line.lo \
+ 	kvu_locks.lo kvu_message_item.lo kvu_numtostr.lo \
+ 	kvu_procedure_timer.lo kvu_rtcaps.lo \
+ 	kvu_temporary_file_directory.lo kvu_threads.lo kvu_utils.lo \
+@@ -305,7 +305,6 @@ INCLUDES = $(ECA_S_EXTRA_CPPFLAGS)
+ kvutil_sources = kvu_dbc.cpp \
+ 			kvu_debug.cpp \
+ 			kvu_com_line.cpp \
+-			kvu_fd_io.cpp \
+ 			kvu_locks.cpp \
+ 			kvu_message_item.cpp \
+ 			kvu_numtostr.cpp \
+@@ -321,7 +320,6 @@ kvutil_headers = kvu_dbc.h \
+ 			kvu_debug.h \
+ 			kvu_definition_by_contract.h \
+ 			kvu_com_line.h \
+-			kvu_fd_io.h \
+ 			kvu_inttypes.h \
+ 			kvu_locks.h \
+ 			kvu_message_item.h \
+@@ -428,7 +426,6 @@ distclean-compile:
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/kvu_com_line.Plo@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/kvu_dbc.Plo@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/kvu_debug.Plo@am__quote@
+-@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/kvu_fd_io.Plo@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/kvu_locks.Plo@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/kvu_message_item.Plo@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/kvu_numtostr.Plo@am__quote@
+diff --git a/kvutils/kvu_fd_io.cpp b/kvutils/kvu_fd_io.cpp
+deleted file mode 100644
+index e3def03..0000000
+--- a/kvutils/kvu_fd_io.cpp
++++ /dev/null
+@@ -1,125 +0,0 @@
+-// ------------------------------------------------------------------------
+-// kvu_fd_io.cpp: Helper functions for reading from, writing to and 
+-//                waiting on UNIX file descriptors.
+-//
+-// Copyright (C) 2002 Kai Vehmanen
+-//
+-// This program is free software; you can redistribute it and/or modify
+-// it under the terms of the GNU General Public License as published by
+-// the Free Software Foundation; either version 2 of the License, or
+-// (at your option) any later version.
+-// 
+-// This program is distributed in the hope that it will be useful,
+-// but WITHOUT ANY WARRANTY; without even the implied warranty of
+-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-// GNU General Public License for more details.
+-// 
+-// You should have received a copy of the GNU General Public License
+-// along with this program; if not, write to the Free Software
+-// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA
+-// ------------------------------------------------------------------------
+-
+-#include <unistd.h>      /* POSIX: read()/write() */
+-#include <sys/poll.h>    /* XPG4-UNIX: poll() */
+-
+-#include "kvu_fd_io.h"
+-
+-/**
+- * Attempts to read up to 'count' bytes from file descriptor 'fd' 
+- * into the buffer starting at 'buf'. If no data is available
+- * for reading, up to 'timeout' milliseconds will be waited. 
+- * A negative value means infinite timeout.
+- */
+-ssize_t kvu_fd_read(int fd, void *buf, size_t count, int timeout)
+-{
+-  int nfds = 1;
+-  struct pollfd ufds;
+-  ssize_t rescount = 0;
+-
+-  ufds.fd = fd;
+-  ufds.events = POLLIN | POLLPRI;
+-  ufds.revents = 0;
+-  
+-  int ret = poll(&ufds, nfds, timeout);
+-  if (ret > 0) {
+-    if (ufds.revents & POLLIN ||
+-	ufds.revents & POLLPRI) {
+-      rescount = ::read(fd, buf, count);
+-    }
+-  }
+-  else if (ret == 0) {
+-    /* timeout */
+-    rescount = -1;
+-  }
+-  return(rescount);
+-}
+-
+-/**
+- * Attempts to write up to 'count' bytes to file descriptor 'fd'
+- * from the buffer starting at 'buf'. If no space is available
+- * for writing, up to 'timeout' milliseconds will be waited. 
+- * A negative value means infinite timeout.
+- */
+-ssize_t kvu_fd_write(int fd, const void *buf, size_t count, int timeout)
+-{
+-  int nfds = 1;
+-  struct pollfd ufds;
+-  ssize_t rescount = 0;
+-  
+-  ufds.fd = fd;
+-  ufds.events = POLLOUT;
+-  ufds.revents = 0;
+-
+-  int ret = poll(&ufds, nfds, timeout);
+-  if (ret > 0) {
+-    if (ufds.revents & POLLOUT) {
+-      rescount = ::write(fd, buf, count);
+-    }
+-  }
+-  else if (ret == 0) {
+-    /* timeout */
+-    rescount = -1;
+-  }
+-  return(rescount);
+-}
+-
+-/**
+- * Blocks until state of file descriptor 'fd' 
+- * changes. State changes include 'fd' becoming
+- * readable, writing or an error condition.
+- * A maximum of 'timeout' milliseconds will be
+- * waited. A negative value means infinite timeout.
+- *
+- * @return returns 1 for success, 0 for timeout 
+- *         and -1 on error
+- */
+-int kvu_fd_wait(int fd, int timeout)
+-{
+-  int nfds = 1;
+-  struct pollfd ufds;
+-
+-  ufds.fd = fd;
+-  ufds.events = POLLIN | POLLPRI | POLLOUT;
+-  ufds.revents = 0;
+-
+-  int ret = poll(&ufds, nfds, timeout);
+-  if (ret > 0) {
+-    if (ufds.revents & POLLERR ||
+-	ufds.revents & POLLHUP ||
+-	ufds.revents & POLLNVAL) {
+-      /* error */
+-      return(-1);
+-    }
+-    else {
+-      /* success */
+-      return(1);
+-    }
+-  }
+-  else if (ret == 0) {
+-    /* timeout */
+-    return(0);
+-  }
+-
+-  /* error */
+-  return(-1);
+-}
+diff --git a/kvutils/kvu_fd_io.h b/kvutils/kvu_fd_io.h
+deleted file mode 100644
+index 0106e04..0000000
+--- a/kvutils/kvu_fd_io.h
++++ /dev/null
+@@ -1,8 +0,0 @@
+-#ifndef INCLUDED_KVU_FD_IO_H
+-#define INCLUDED_KVU_FD_IO_H
+-
+-ssize_t kvu_fd_read(int fd, void *buf, size_t count, int timeout);
+-ssize_t kvu_fd_write(int fd, const void *buf, size_t count, int timeout);
+-int kvu_fd_wait(int fd, int timeout);
+-
+-#endif
+diff --git a/kvutils/kvu_temporary_file_directory.cpp b/kvutils/kvu_temporary_file_directory.cpp
+index 109b0f1..93225a0 100644
+--- a/kvutils/kvu_temporary_file_directory.cpp
++++ b/kvutils/kvu_temporary_file_directory.cpp
+@@ -58,7 +58,7 @@ void TEMPORARY_FILE_DIRECTORY::reserve_directory(const std::string& dir) {
+ 
+   /* FIXME: add 'unlink(tdir_rep.c_str());' ? */
+ 
+-  int result = mkdir(tdir_rep.c_str(), 0700);
++  int result = mkdir(tdir_rep.c_str());
+   if (result == 0 ||
+       errno == EEXIST) {
+     check_validity();
+-- 
+2.16.2
+

--- a/src/ecasound-2-remove-kvu-temp.patch
+++ b/src/ecasound-2-remove-kvu-temp.patch
@@ -1,0 +1,49 @@
+From 3e3f2742eaf63cd6a44966d0ccb69e97b7e8a8b3 Mon Sep 17 00:00:00 2001
+From: Matthias Geier <Matthias.Geier@gmail.com>
+Date: Wed, 21 Mar 2018 15:48:29 +0100
+Subject: [PATCH] Try to remove kvu_temporary_...
+
+---
+ kvutils/Makefile.in | 5 +----
+ 1 file changed, 1 insertion(+), 4 deletions(-)
+
+diff --git a/kvutils/Makefile.in b/kvutils/Makefile.in
+index 965456b..75c6282 100644
+--- a/kvutils/Makefile.in
++++ b/kvutils/Makefile.in
+@@ -68,7 +68,7 @@ libkvutils_la_LIBADD =
+ am__objects_1 = kvu_dbc.lo kvu_debug.lo kvu_com_line.lo \
+ 	kvu_locks.lo kvu_message_item.lo kvu_numtostr.lo \
+ 	kvu_procedure_timer.lo kvu_rtcaps.lo \
+-	kvu_temporary_file_directory.lo kvu_threads.lo kvu_utils.lo \
++	kvu_threads.lo kvu_utils.lo \
+ 	kvu_timestamp.lo kvu_value_queue.lo
+ am__objects_2 =
+ am_libkvutils_la_OBJECTS = $(am__objects_1) $(am__objects_2)
+@@ -310,7 +310,6 @@ kvutil_sources = kvu_dbc.cpp \
+ 			kvu_numtostr.cpp \
+ 			kvu_procedure_timer.cpp \
+ 			kvu_rtcaps.cpp \
+-			kvu_temporary_file_directory.cpp \
+ 			kvu_threads.cpp \
+ 			kvu_utils.cpp \
+ 			kvu_timestamp.cpp \
+@@ -328,7 +327,6 @@ kvutil_headers = kvu_dbc.h \
+ 			kvu_object_queue.h \
+ 			kvu_procedure_timer.h \
+ 			kvu_rtcaps.h \
+-			kvu_temporary_file_directory.h \
+ 			kvu_threads.h \
+ 			kvu_utils.h \
+ 			kvu_timestamp.h \
+@@ -431,7 +429,6 @@ distclean-compile:
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/kvu_numtostr.Plo@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/kvu_procedure_timer.Plo@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/kvu_rtcaps.Plo@am__quote@
+-@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/kvu_temporary_file_directory.Plo@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/kvu_threads.Plo@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/kvu_timestamp.Plo@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/kvu_utils.Plo@am__quote@
+-- 
+2.16.2
+

--- a/src/ecasound-3-remove-audioio.patch
+++ b/src/ecasound-3-remove-audioio.patch
@@ -1,0 +1,231 @@
+From e10a96f908a7cca940e7e62fd64f418464d4a1f1 Mon Sep 17 00:00:00 2001
+From: Matthias Geier <Matthias.Geier@gmail.com>
+Date: Wed, 21 Mar 2018 16:00:29 +0100
+Subject: [PATCH] Remove audioio stuff
+
+---
+ libecasound/Makefile.in | 138 ++----------------------------------------------
+ 1 file changed, 4 insertions(+), 134 deletions(-)
+
+diff --git a/libecasound/Makefile.in b/libecasound/Makefile.in
+index 9e25b94..e1df1c7 100644
+--- a/libecasound/Makefile.in
++++ b/libecasound/Makefile.in
+@@ -71,17 +71,7 @@ am__DEPENDENCIES_1 =
+ @ECA_AM_DEBUG_MODE_TRUE@am__DEPENDENCIES_2 = $(top_builddir)/libecasound/plugins/libecasound_plugins_debug.la \
+ @ECA_AM_DEBUG_MODE_TRUE@	$(am__DEPENDENCIES_1)
+ libecasound_la_DEPENDENCIES = $(am__DEPENDENCIES_2)
+-am__libecasound_la_SOURCES_DIST = audioio-cdr.cpp audioio-ewf.cpp \
+-	audioio-mp3.cpp audioio-ogg.cpp audioio-wave.cpp audioio.cpp \
+-	audioio-buffered.cpp audioio-device.cpp audioio-null.cpp \
+-	audioio-raw.cpp audioio-mikmod.cpp audioio-rtnull.cpp \
+-	audioio-loop.cpp audioio-forked-stream.cpp \
+-	audioio-timidity.cpp audioio-db-server.cpp \
+-	audioio-db-buffer.cpp audioio-db-client.cpp \
+-	audioio-typeselect.cpp audioio-resample.cpp \
+-	audioio-reverse.cpp audioio-proxy.cpp audioio-flac.cpp \
+-	audioio-aac.cpp audioio-tone.cpp audioio-seqbase.cpp \
+-	audioio-acseq.cpp audioio-oss.cpp jack-connections.cpp \
++am__libecasound_la_SOURCES_DIST = \
+ 	midi-server.cpp midi-client.cpp midi-parser.cpp midiio.cpp \
+ 	midiio-raw.cpp midiio-aseq.cpp eca-chain.cpp eca-engine.cpp \
+ 	samplebuffer.cpp samplebuffer_functions.cpp eca-session.cpp \
+@@ -108,16 +98,7 @@ am__libecasound_la_SOURCES_DIST = audioio-cdr.cpp audioio-ewf.cpp \
+ 	midi-cc.cpp osc-gen.cpp osc-gen-file.cpp osc-sine.cpp \
+ 	linear-envelope.cpp two-stage-linear-envelope.cpp \
+ 	stamp-ctrl.cpp generic-linear-envelope.cpp
+-am__objects_1 = audioio-cdr.lo audioio-ewf.lo audioio-mp3.lo \
+-	audioio-ogg.lo audioio-wave.lo audioio.lo audioio-buffered.lo \
+-	audioio-device.lo audioio-null.lo audioio-raw.lo \
+-	audioio-mikmod.lo audioio-rtnull.lo audioio-loop.lo \
+-	audioio-forked-stream.lo audioio-timidity.lo \
+-	audioio-db-server.lo audioio-db-buffer.lo audioio-db-client.lo \
+-	audioio-typeselect.lo audioio-resample.lo audioio-reverse.lo \
+-	audioio-proxy.lo audioio-flac.lo audioio-aac.lo \
+-	audioio-tone.lo audioio-seqbase.lo audioio-acseq.lo
+-@ECA_AM_COMPILE_OSS_TRUE@am__objects_2 = audioio-oss.lo
++am__objects_1 = \
+ @ECA_AM_COMPILE_JACK_TRUE@am__objects_3 = jack-connections.lo
+ am__objects_4 = midi-server.lo midi-client.lo midi-parser.lo midiio.lo \
+ 	midiio-raw.lo midiio-aseq.lo
+@@ -155,17 +136,7 @@ libecasound_la_OBJECTS = $(am_libecasound_la_OBJECTS)
+ @ECA_AM_DEBUG_MODE_FALSE@am_libecasound_la_rpath = -rpath $(libdir)
+ am__DEPENDENCIES_3 = $(am__DEPENDENCIES_2)
+ libecasound_debug_la_DEPENDENCIES = $(am__DEPENDENCIES_3)
+-am__libecasound_debug_la_SOURCES_DIST = audioio-cdr.cpp \
+-	audioio-ewf.cpp audioio-mp3.cpp audioio-ogg.cpp \
+-	audioio-wave.cpp audioio.cpp audioio-buffered.cpp \
+-	audioio-device.cpp audioio-null.cpp audioio-raw.cpp \
+-	audioio-mikmod.cpp audioio-rtnull.cpp audioio-loop.cpp \
+-	audioio-forked-stream.cpp audioio-timidity.cpp \
+-	audioio-db-server.cpp audioio-db-buffer.cpp \
+-	audioio-db-client.cpp audioio-typeselect.cpp \
+-	audioio-resample.cpp audioio-reverse.cpp audioio-proxy.cpp \
+-	audioio-flac.cpp audioio-aac.cpp audioio-tone.cpp \
+-	audioio-seqbase.cpp audioio-acseq.cpp audioio-oss.cpp \
++am__libecasound_debug_la_SOURCES_DIST = \
+ 	jack-connections.cpp midi-server.cpp midi-client.cpp \
+ 	midi-parser.cpp midiio.cpp midiio-raw.cpp midiio-aseq.cpp \
+ 	eca-chain.cpp eca-engine.cpp samplebuffer.cpp \
+@@ -479,43 +450,6 @@ ecasound_preset_include = \
+ 			file-preset.h \
+ 			global-preset.h
+ 
+-ecasound_audioio_include = \
+-			audioio.h \
+-			audioio-buffered.h \
+-			audioio-device.h \
+-			audioio-plugin.h \
+-			audioio-manager.h \
+-			audioio-cdr.h \
+-			audioio-cdr_impl.h \
+-			audioio-ewf.h \
+-			audioio-mp3.h \
+-			audioio-mp3_impl.h \
+-			audioio-ogg.h \
+-			audioio-wave.h \
+-			audioio-raw.h \
+-			audioio-oss.h \
+-			audioio-oss_impl.h \
+-			audioio-null.h \
+-			audioio-rtnull.h \
+-			audioio-mikmod.h \
+-			audioio-loop.h \
+-			audioio-forked-stream.h \
+-			audioio-timidity.h \
+-			audioio-db-server.h \
+-			audioio-db-server_impl.h \
+-			audioio-db-buffer.h \
+-			audioio-db-client.h \
+-			audioio-proxy.h \
+-			audioio-typeselect.h \
+-			audioio-resample.h \
+-			audioio-reverse.h \
+-			audioio-flac.h \
+-			audioio-aac.h \
+-			audioio-tone.h \
+-			audioio-seqbase.h \
+-			audioio-acseq.h \
+-			audioio-barrier.h
+-
+ ecasound_midi_include = \
+ 			midi-server.h \
+ 			midi-client.h \
+@@ -597,8 +531,6 @@ ecasound_test_framework_include = \
+ 			eca-test-repository.h \
+ 			eca-test-case.h \
+ 			audiofx_amplitude_test.h \
+-			audioio_test.h \
+-			audioio-device_test.h \
+ 			eca-audio-time_test.h \
+ 			eca-chainsetup_test.h \
+ 			eca-chainsetup-parser_test.h \
+@@ -614,7 +546,6 @@ ecasound_test_framework_include = \
+ #       uninstall-data targets
+ noinst_HEADERS = $(ecasound_audiofx_include) \
+ 			$(ecasound_preset_include) \
+-			$(ecasound_audioio_include) \
+ 			$(ecasound_midi_include) \
+ 		 	$(ecasound_controller_include) \
+ 			$(ecasound_general_include) \
+@@ -646,36 +577,6 @@ ecasound_preset_src = global-preset.cpp \
+ 			preset.cpp \
+ 			file-preset.cpp
+ 
+-ecasound_audioio1_src = audioio-cdr.cpp \
+-			audioio-ewf.cpp \
+-			audioio-mp3.cpp \
+-			audioio-ogg.cpp \
+-			audioio-wave.cpp \
+-			audioio.cpp \
+-			audioio-buffered.cpp \
+-			audioio-device.cpp \
+-			audioio-null.cpp \
+-			audioio-raw.cpp \
+-			audioio-mikmod.cpp \
+-			audioio-rtnull.cpp \
+-			audioio-loop.cpp \
+-			audioio-forked-stream.cpp \
+-			audioio-timidity.cpp \
+-			audioio-db-server.cpp \
+-			audioio-db-buffer.cpp \
+-			audioio-db-client.cpp \
+-			audioio-typeselect.cpp \
+-			audioio-resample.cpp \
+-			audioio-reverse.cpp \
+-			audioio-proxy.cpp \
+-			audioio-flac.cpp \
+-			audioio-aac.cpp \
+-			audioio-tone.cpp \
+-			audioio-seqbase.cpp \
+-			audioio-acseq.cpp
+-
+-@ECA_AM_COMPILE_OSS_FALSE@ecasound_audioio2_src = 
+-@ECA_AM_COMPILE_OSS_TRUE@ecasound_audioio2_src = audioio-oss.cpp
+ @ECA_AM_COMPILE_JACK_FALSE@jack_connections_src = 
+ @ECA_AM_COMPILE_JACK_TRUE@jack_connections_src = jack-connections.cpp
+ ecasound_midi_src = \
+@@ -735,8 +636,7 @@ ecasound_general_src = eca-chain.cpp \
+ 			eca-object-map.cpp \
+ 			eca-preset-map.cpp
+ 
+-ecasound_common1_src = $(ecasound_audioio1_src) \
+-			$(ecasound_audioio2_src) \
++ecasound_common1_src = \
+ 			$(jack_connections_src) \
+ 			$(ecasound_midi_src) \
+ 			$(ecasound_general_src)
+@@ -859,34 +759,6 @@ distclean-compile:
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/audiofx_reverb.Plo@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/audiofx_timebased.Plo@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/audiogate.Plo@am__quote@
+-@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/audioio-aac.Plo@am__quote@
+-@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/audioio-acseq.Plo@am__quote@
+-@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/audioio-buffered.Plo@am__quote@
+-@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/audioio-cdr.Plo@am__quote@
+-@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/audioio-db-buffer.Plo@am__quote@
+-@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/audioio-db-client.Plo@am__quote@
+-@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/audioio-db-server.Plo@am__quote@
+-@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/audioio-device.Plo@am__quote@
+-@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/audioio-ewf.Plo@am__quote@
+-@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/audioio-flac.Plo@am__quote@
+-@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/audioio-forked-stream.Plo@am__quote@
+-@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/audioio-loop.Plo@am__quote@
+-@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/audioio-mikmod.Plo@am__quote@
+-@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/audioio-mp3.Plo@am__quote@
+-@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/audioio-null.Plo@am__quote@
+-@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/audioio-ogg.Plo@am__quote@
+-@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/audioio-oss.Plo@am__quote@
+-@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/audioio-proxy.Plo@am__quote@
+-@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/audioio-raw.Plo@am__quote@
+-@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/audioio-resample.Plo@am__quote@
+-@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/audioio-reverse.Plo@am__quote@
+-@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/audioio-rtnull.Plo@am__quote@
+-@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/audioio-seqbase.Plo@am__quote@
+-@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/audioio-timidity.Plo@am__quote@
+-@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/audioio-tone.Plo@am__quote@
+-@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/audioio-typeselect.Plo@am__quote@
+-@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/audioio-wave.Plo@am__quote@
+-@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/audioio.Plo@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eca-audio-format.Plo@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eca-audio-position.Plo@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eca-audio-time.Plo@am__quote@
+@@ -1339,7 +1211,6 @@ install-data-local:
+ 	$(INSTALL_DATA) \
+ 		$(ecasound_audiofx_include) \
+ 		$(ecasound_preset_include) \
+-		$(ecasound_audioio_include) \
+ 		$(ecasound_controller_include) \
+ 		$(ecasound_midi_include) \
+ 		$(ecasound_general_include) \
+@@ -1353,7 +1224,6 @@ uninstall-local:
+ 	cd $(DESTDIR)$(includedir)/libecasound && \
+ 	rm -f   $(ecasound_audiofx_include) \
+ 		$(ecasound_preset_include) \
+-		$(ecasound_audioio_include) \
+ 		$(ecasound_controller_include) \
+ 		$(ecasound_midi_include) \
+ 		$(ecasound_general_include)
+-- 
+2.16.2
+

--- a/src/ecasound-4-am__objects_1-error.patch
+++ b/src/ecasound-4-am__objects_1-error.patch
@@ -1,0 +1,24 @@
+From 8e119777e0e333e53877ab68d0fd804394dd8a2c Mon Sep 17 00:00:00 2001
+From: Matthias Geier <Matthias.Geier@gmail.com>
+Date: Wed, 21 Mar 2018 16:18:28 +0100
+Subject: [PATCH] am__objects_1 error
+
+---
+ libecasound/Makefile.in | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/libecasound/Makefile.in b/libecasound/Makefile.in
+index e1df1c7..8ae62a0 100644
+--- a/libecasound/Makefile.in
++++ b/libecasound/Makefile.in
+@@ -98,7 +98,6 @@ am__libecasound_la_SOURCES_DIST = \
+ 	midi-cc.cpp osc-gen.cpp osc-gen-file.cpp osc-sine.cpp \
+ 	linear-envelope.cpp two-stage-linear-envelope.cpp \
+ 	stamp-ctrl.cpp generic-linear-envelope.cpp
+-am__objects_1 = \
+ @ECA_AM_COMPILE_JACK_TRUE@am__objects_3 = jack-connections.lo
+ am__objects_4 = midi-server.lo midi-client.lo midi-parser.lo midiio.lo \
+ 	midiio-raw.lo midiio-aseq.lo
+-- 
+2.16.2
+

--- a/src/ecasound-4-cru.patch
+++ b/src/ecasound-4-cru.patch
@@ -1,0 +1,25 @@
+From 2ff9b5fcb805d700810d052a0547d446a688f549 Mon Sep 17 00:00:00 2001
+From: Matthias Geier <Matthias.Geier@gmail.com>
+Date: Wed, 21 Mar 2018 16:11:46 +0100
+Subject: [PATCH] cru -> cr
+
+---
+ configure | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/configure b/configure
+index cfe0ede..a5ed7da 100755
+--- a/configure
++++ b/configure
+@@ -7761,7 +7761,7 @@ else
+ fi
+ 
+ test -z "$AR" && AR=ar
+-test -z "$AR_FLAGS" && AR_FLAGS=cru
++test -z "$AR_FLAGS" && AR_FLAGS=cr
+ 
+ 
+ 
+-- 
+2.16.2
+

--- a/src/ecasound-6-remove-midi.patch
+++ b/src/ecasound-6-remove-midi.patch
@@ -1,0 +1,149 @@
+From 5f278bf5ff5345bf928d33b8cc1edadd36510f65 Mon Sep 17 00:00:00 2001
+From: Matthias Geier <Matthias.Geier@gmail.com>
+Date: Wed, 21 Mar 2018 16:21:43 +0100
+Subject: [PATCH] Remove MIDI stuff
+
+---
+ libecasound/Makefile.in | 42 +++++-------------------------------------
+ 1 file changed, 5 insertions(+), 37 deletions(-)
+
+diff --git a/libecasound/Makefile.in b/libecasound/Makefile.in
+index 8ae62a0..9aedce3 100644
+--- a/libecasound/Makefile.in
++++ b/libecasound/Makefile.in
+@@ -72,8 +72,7 @@ am__DEPENDENCIES_1 =
+ @ECA_AM_DEBUG_MODE_TRUE@	$(am__DEPENDENCIES_1)
+ libecasound_la_DEPENDENCIES = $(am__DEPENDENCIES_2)
+ am__libecasound_la_SOURCES_DIST = \
+-	midi-server.cpp midi-client.cpp midi-parser.cpp midiio.cpp \
+-	midiio-raw.cpp midiio-aseq.cpp eca-chain.cpp eca-engine.cpp \
++	eca-chain.cpp eca-engine.cpp \
+ 	samplebuffer.cpp samplebuffer_functions.cpp eca-session.cpp \
+ 	eca-resources.cpp resource-file.cpp eca-logger.cpp \
+ 	eca-logger-default.cpp eca-logger-interface.cpp \
+@@ -95,12 +94,10 @@ am__libecasound_la_SOURCES_DIST = \
+ 	audiofx_timebased.cpp audiogate.cpp audiofx_mixing.cpp \
+ 	audiofx_ladspa.cpp audiofx_lv2.cpp audiofx_lv2_world.cpp \
+ 	audio-stamp.cpp global-preset.cpp preset.cpp file-preset.cpp \
+-	midi-cc.cpp osc-gen.cpp osc-gen-file.cpp osc-sine.cpp \
++	osc-gen.cpp osc-gen-file.cpp osc-sine.cpp \
+ 	linear-envelope.cpp two-stage-linear-envelope.cpp \
+ 	stamp-ctrl.cpp generic-linear-envelope.cpp
+ @ECA_AM_COMPILE_JACK_TRUE@am__objects_3 = jack-connections.lo
+-am__objects_4 = midi-server.lo midi-client.lo midi-parser.lo midiio.lo \
+-	midiio-raw.lo midiio-aseq.lo
+ am__objects_5 = eca-chain.lo eca-engine.lo samplebuffer.lo \
+ 	samplebuffer_functions.lo eca-session.lo eca-resources.lo \
+ 	resource-file.lo eca-logger.lo eca-logger-default.lo \
+@@ -124,7 +121,7 @@ am__objects_7 = audiofx.lo audiofx_misc.lo audiofx_amplitude.lo \
+ 	audiogate.lo audiofx_mixing.lo audiofx_ladspa.lo \
+ 	audiofx_lv2.lo audiofx_lv2_world.lo audio-stamp.lo
+ am__objects_8 = global-preset.lo preset.lo file-preset.lo
+-am__objects_9 = midi-cc.lo osc-gen.lo osc-gen-file.lo osc-sine.lo \
++am__objects_9 = osc-gen.lo osc-gen-file.lo osc-sine.lo \
+ 	linear-envelope.lo two-stage-linear-envelope.lo stamp-ctrl.lo \
+ 	generic-linear-envelope.lo
+ @ECA_AM_DISABLE_EFFECTS_FALSE@am__objects_10 = $(am__objects_7) \
+@@ -136,8 +133,7 @@ libecasound_la_OBJECTS = $(am_libecasound_la_OBJECTS)
+ am__DEPENDENCIES_3 = $(am__DEPENDENCIES_2)
+ libecasound_debug_la_DEPENDENCIES = $(am__DEPENDENCIES_3)
+ am__libecasound_debug_la_SOURCES_DIST = \
+-	jack-connections.cpp midi-server.cpp midi-client.cpp \
+-	midi-parser.cpp midiio.cpp midiio-raw.cpp midiio-aseq.cpp \
++	jack-connections.cpp \
+ 	eca-chain.cpp eca-engine.cpp samplebuffer.cpp \
+ 	samplebuffer_functions.cpp eca-session.cpp eca-resources.cpp \
+ 	resource-file.cpp eca-logger.cpp eca-logger-default.cpp \
+@@ -159,7 +155,7 @@ am__libecasound_debug_la_SOURCES_DIST = \
+ 	audiofx_timebased.cpp audiogate.cpp audiofx_mixing.cpp \
+ 	audiofx_ladspa.cpp audiofx_lv2.cpp audiofx_lv2_world.cpp \
+ 	audio-stamp.cpp global-preset.cpp preset.cpp file-preset.cpp \
+-	midi-cc.cpp osc-gen.cpp osc-gen-file.cpp osc-sine.cpp \
++	osc-gen.cpp osc-gen-file.cpp osc-sine.cpp \
+ 	linear-envelope.cpp two-stage-linear-envelope.cpp \
+ 	stamp-ctrl.cpp generic-linear-envelope.cpp
+ am_libecasound_debug_la_OBJECTS = $(am__objects_6) $(am__objects_10)
+@@ -449,17 +445,8 @@ ecasound_preset_include = \
+ 			file-preset.h \
+ 			global-preset.h
+ 
+-ecasound_midi_include = \
+-			midi-server.h \
+-			midi-client.h \
+-			midi-parser.h \
+-			midiio.h \
+-			midiio-raw.h \
+-			midiio-aseq.h
+-
+ ecasound_controller_include = \
+ 			ctrl-source.h \
+-			midi-cc.h \
+ 			oscillator.h \
+ 			osc-gen.h \
+ 			osc-gen-file.h \
+@@ -545,7 +532,6 @@ ecasound_test_framework_include = \
+ #       uninstall-data targets
+ noinst_HEADERS = $(ecasound_audiofx_include) \
+ 			$(ecasound_preset_include) \
+-			$(ecasound_midi_include) \
+ 		 	$(ecasound_controller_include) \
+ 			$(ecasound_general_include) \
+ 			$(ecasound_extra_include) \
+@@ -578,16 +564,8 @@ ecasound_preset_src = global-preset.cpp \
+ 
+ @ECA_AM_COMPILE_JACK_FALSE@jack_connections_src = 
+ @ECA_AM_COMPILE_JACK_TRUE@jack_connections_src = jack-connections.cpp
+-ecasound_midi_src = \
+-			midi-server.cpp \
+-			midi-client.cpp \
+-			midi-parser.cpp \
+-			midiio.cpp \
+-			midiio-raw.cpp \
+-			midiio-aseq.cpp
+ 
+ ecasound_controller_src = \
+-			midi-cc.cpp \
+ 			osc-gen.cpp \
+ 			osc-gen-file.cpp \
+ 			osc-sine.cpp \
+@@ -637,7 +615,6 @@ ecasound_general_src = eca-chain.cpp \
+ 
+ ecasound_common1_src = \
+ 			$(jack_connections_src) \
+-			$(ecasound_midi_src) \
+ 			$(ecasound_general_src)
+ 
+ @ECA_AM_DISABLE_EFFECTS_FALSE@ecasound_common2_src = $(ecasound_audiofx_src) \
+@@ -800,13 +777,6 @@ distclean-compile:
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/layer.Plo@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/libecasound_tester.Po@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/linear-envelope.Plo@am__quote@
+-@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/midi-cc.Plo@am__quote@
+-@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/midi-client.Plo@am__quote@
+-@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/midi-parser.Plo@am__quote@
+-@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/midi-server.Plo@am__quote@
+-@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/midiio-aseq.Plo@am__quote@
+-@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/midiio-raw.Plo@am__quote@
+-@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/midiio.Plo@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/osc-gen-file.Plo@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/osc-gen.Plo@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/osc-sine.Plo@am__quote@
+@@ -1211,7 +1181,6 @@ install-data-local:
+ 		$(ecasound_audiofx_include) \
+ 		$(ecasound_preset_include) \
+ 		$(ecasound_controller_include) \
+-		$(ecasound_midi_include) \
+ 		$(ecasound_general_include) \
+ 		$(DESTDIR)$(includedir)/libecasound
+ 	$(INSTALL) -d $(DESTDIR)$(bindir)
+@@ -1224,7 +1193,6 @@ uninstall-local:
+ 	rm -f   $(ecasound_audiofx_include) \
+ 		$(ecasound_preset_include) \
+ 		$(ecasound_controller_include) \
+-		$(ecasound_midi_include) \
+ 		$(ecasound_general_include)
+ 	rmdir $(DESTDIR)$(includedir)/libecasound || echo "Skipping"
+ 	rm -f 	$(DESTDIR)$(bindir)/libecasound-config
+-- 
+2.16.2
+

--- a/src/ecasound-7-long-long.patch
+++ b/src/ecasound-7-long-long.patch
@@ -1,0 +1,25 @@
+From 92560787c9b4b5f0aab772a4a4bfa8673fa55cee Mon Sep 17 00:00:00 2001
+From: Matthias Geier <Matthias.Geier@gmail.com>
+Date: Wed, 21 Mar 2018 16:26:25 +0100
+Subject: [PATCH] long long
+
+---
+ libecasound/eca-chain.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/libecasound/eca-chain.cpp b/libecasound/eca-chain.cpp
+index 11b1f66..80786eb 100644
+--- a/libecasound/eca-chain.cpp
++++ b/libecasound/eca-chain.cpp
+@@ -796,7 +796,7 @@ void CHAIN::init(SAMPLE_BUFFER* sbuf, int in_channels, int out_channels)
+ 	      " chainops and " +
+ 	      kvu_numtostr(gcontrollers_rep.size()) +
+ 	      " gcontrollers. Sbuf points to " +
+-	      kvu_numtostr(reinterpret_cast<long int>(audioslot_repp)) + ".");
++	      kvu_numtostr(reinterpret_cast<long long>(audioslot_repp)) + ".");
+   
+   // --------
+   DBC_ENSURE(is_initialized() == true);
+-- 
+2.16.2
+

--- a/src/ecasound.mk
+++ b/src/ecasound.mk
@@ -30,6 +30,6 @@ define $(PKG)_BUILD
         --disable-rubyecasound \
         --disable-audiofile \
         --disable-ncurses
-    $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)' $(MXE_DISABLE_CRUFT)
+    $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)' $(MXE_DISABLE_CRUFT) CXXFLAGS=-Wno-deprecated-declarations
     $(MAKE) -C '$(BUILD_DIR)' -j 1 install $(MXE_DISABLE_CRUFT)
 endef

--- a/src/ecasound.mk
+++ b/src/ecasound.mk
@@ -18,12 +18,13 @@ define $(PKG)_UPDATE
 endef
 
 define $(PKG)_BUILD
-    cd '$(1)' && ./configure \
+    cd '$(BUILD_DIR)' && '$(SOURCE_DIR)'/configure \
         $(MXE_CONFIGURE_OPTS) \
 	--enable-libsamplerate \
 	--enable-sndfile \
 	--enable-liboil \
 	--enable-liblo \
 	--enable-jack
-    $(MAKE) -C '$(1)' -j '$(JOBS)' install $(MXE_DISABLE_CRUFT)
+    $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)' $(MXE_DISABLE_CRUFT)
+    $(MAKE) -C '$(BUILD_DIR)' -j 1 install $(MXE_DISABLE_CRUFT)
 endef

--- a/src/ecasound.mk
+++ b/src/ecasound.mk
@@ -20,11 +20,16 @@ endef
 define $(PKG)_BUILD
     cd '$(BUILD_DIR)' && '$(SOURCE_DIR)'/configure \
         $(MXE_CONFIGURE_OPTS) \
-	--enable-libsamplerate \
-	--enable-sndfile \
-	--enable-liboil \
-	--enable-liblo \
-	--enable-jack
+        --enable-libsamplerate \
+        --enable-sndfile \
+        --enable-liboil \
+        --enable-liblo \
+        --enable-jack \
+        --disable-alsa \
+        --disable-pyecasound \
+        --disable-rubyecasound \
+        --disable-audiofile \
+        --disable-ncurses
     $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)' $(MXE_DISABLE_CRUFT)
     $(MAKE) -C '$(BUILD_DIR)' -j 1 install $(MXE_DISABLE_CRUFT)
 endef

--- a/src/ecasound.mk
+++ b/src/ecasound.mk
@@ -1,0 +1,29 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+PKG             := ecasound
+$(PKG)_WEBSITE  := https://ecasound.seul.org/
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := 2.9.1
+$(PKG)_CHECKSUM := 39fce8becd84d80620fa3de31fb5223b2b7d4648d36c9c337d3739c2fad0dcf3
+$(PKG)_SUBDIR   := ecasound-$($(PKG)_VERSION)
+$(PKG)_FILE     := ecasound-$($(PKG)_VERSION).tar.gz
+$(PKG)_URL      := https://ecasound.seul.org/download/$($(PKG)_FILE)
+$(PKG)_DEPS     := cc libsamplerate libsndfile liboil jack
+
+define $(PKG)_UPDATE
+    $(WGET) -q -O- 'https://ecasound.seul.org/download/' | \
+    $(SED) -n 's,.*href="ecasound-\([0-9][^"<>]*\)\.tar\.gz.*,\1,p' | \
+    $(SORT) -V | \
+    tail -1
+endef
+
+define $(PKG)_BUILD
+    cd '$(1)' && ./configure \
+        $(MXE_CONFIGURE_OPTS) \
+	--enable-libsamplerate \
+	--enable-sndfile \
+	--enable-liboil \
+	--enable-liblo \
+	--enable-jack
+    $(MAKE) -C '$(1)' -j '$(JOBS)' install $(MXE_DISABLE_CRUFT)
+endef


### PR DESCRIPTION
Note that JACK can currently only be compiled in "shared" mode, see https://github.com/mxe/mxe/issues/1881.

I've used this to compile:

    make ecasound MXE_TARGETS=x86_64-w64-mingw32.shared

For 32-bit it probably works like this:

    make ecasound MXE_TARGETS=i686-w64-mingw32.shared

The optional dependencies `libaudiofile` and `liblilv` are currently not available in MXE.

Currently this fails during `./configure`:

    checking for library containing inet_ntoa... no

This doesn't seem to exist on MinGW: https://www.gnu.org/software/gnulib/manual/html_node/inet_005fntoa.html

But it seems to be in Winsock: https://msdn.microsoft.com/en-us/library/ms738564(v=vs.85).aspx (probably in the `ws2_32` library?).